### PR TITLE
Fix meta tag formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8"/>
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>ELIASTORK LTD – Engineering & Supply Solutions</title>
   <style>
     body {


### PR DESCRIPTION
## Summary
- remove XHTML-style trailing slashes from `<meta>` tags

## Testing
- `grep -n '/>' index.html`

------
https://chatgpt.com/codex/tasks/task_e_68823980b1bc8322912211008c60aba5